### PR TITLE
Fix a bug that causes a StringIndexOutOfBoundsException

### DIFF
--- a/buildSrc/src/main/java/com.chrynan.uri.buildSrc/LibraryConstants.kt
+++ b/buildSrc/src/main/java/com.chrynan.uri.buildSrc/LibraryConstants.kt
@@ -5,8 +5,8 @@ object LibraryConstants {
     const val group = "com.chrynan.uri"
     const val owner = "chrynan"
     const val repoName = "uri"
-    const val versionName = "0.4.0"
-    const val versionCode = 7
+    const val versionName = "0.4.1"
+    const val versionCode = 8
     const val versionDescription = "Release $versionName ($versionCode)"
     const val license = "Apache-2.0"
     const val vcsUrl = "https://github.com/chRyNaN/uri.git"

--- a/uri-core/src/commonMain/kotlin/com.chrynan.uri.core/UriCreationUtils.kt
+++ b/uri-core/src/commonMain/kotlin/com.chrynan.uri.core/UriCreationUtils.kt
@@ -59,8 +59,8 @@ fun Uri.Companion.fromString(uriString: UriString): Uri {
             val userInfo =
                 if (userInfoEndIndex == -1) null else authority?.substring(startIndex = 0, endIndex = userInfoEndIndex)
 
-            val host = authority?.let {
-                val hostStartIndex = if (userInfoEndIndex == -1) 0 else userInfoEndIndex + 1
+            val hostStartIndex = if (userInfoEndIndex == -1) 0 else userInfoEndIndex + 1
+            val host = authority?.substring(hostStartIndex)?.let {
                 var hostIpv6EndIndex = it.indexOf(HOST_IPV6_END_DELIMITER)
                 var portStartIndex = it.indexOf(PORT_START_DELIMITER)
 


### PR DESCRIPTION
- Fix a bug that causes a StringIndexOutOfBoundsException for some user info cases when extracting the host in `Uri.Companion.fromString(UriString)`

- Bump version to 0.4.1 (8)